### PR TITLE
Add an RPC graph service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,8 +288,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -395,8 +395,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -976,11 +976,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "0.15.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1000,8 +1000,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1366,7 +1366,7 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
@@ -1399,7 +1399,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+"checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
 "checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/src/engine/speaker.rs
+++ b/src/engine/speaker.rs
@@ -3,7 +3,6 @@ use crate::audioformat::{StandardFrame, empty_standard_frame, STANDARD_CHANNELS,
 use crate::graph::SharedAudioGraph;
 use std::sync::mpsc;
 use std::thread;
-use dsp::Node;
 use dsp::sample::{Sample, Frame, FromSample, conv::ToFrameSliceMut};
 use cpal::{StreamData, UnknownTypeOutputBuffer, OutputBuffer};
 use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
@@ -55,8 +54,8 @@ impl AudioEngine for SpeakerEngine {
 						ControlMsg::Pause => {
 							with_buffer_of!(data, write_silence);
 							paused = true
-						},
-						_ => println!("Control message not recognized by the speaker/CPAL engine: {:?}", msg)
+						}
+						// _ => println!("Control message not recognized by the speaker/CPAL engine: {:?}", msg)
 					}
 				}
 			

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -76,13 +76,14 @@ impl AudioGraph {
 		}
 	}
 	
-	/// Removes a node from the graph in O(1).
+	/// Removes a node from the graph.
 	/// 
 	/// Any indices referring to the given node should
 	/// be dropped by now.
 	pub fn remove_node(&mut self, node: NodeIndex) {
-		*self.node_mut(node).expect("Tried to remove non-existing node") = DspNode::Empty;
 		self.free[node.index()] = true;
+		self.inner.remove_all_input_connections(node);
+		self.inner.remove_all_output_connections(node);
 		self.has_free = true;
 	}
 	

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -136,6 +136,11 @@ impl AudioGraph {
 		self.inner.set_master(master);
 	}
 	
+	/// Fetches the master (output) node of this graph
+	pub fn master(&self) -> Option<NodeIndex> {
+		self.inner.master_index()
+	}
+	
 	/// Requests audio from the master node
 	#[inline]
 	pub fn audio_requested(&mut self, output: &mut [StandardFrame], sample_hz: f64) {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,13 +1,145 @@
-use dsp::Graph;
 use std::sync::{Arc, Mutex};
+use dsp::Node;
 use crate::processing::DspNode;
 use crate::audioformat::StandardFrame;
+
+pub type NodeIndex = dsp::NodeIndex;
+pub type EdgeIndex = dsp::EdgeIndex;
+pub type WouldCycle = dsp::WouldCycle;
+
+/// A wrapper around the dsp graph whose node
+/// indices remain stable after removals.
+pub struct AudioGraph {
+	inner: dsp::Graph<StandardFrame, DspNode>,
+	free: Vec<bool>
+}
+
+impl AudioGraph {
+	pub fn new() -> AudioGraph {
+		AudioGraph { inner: dsp::Graph::new(), free: Vec::new() }
+	}
+
+	/// Adds the given node to the graph in O(1)
+	pub fn add_node(&mut self, node: DspNode) -> NodeIndex {
+		let index = self.inner.add_node(node);
+		self.free.insert(index.index(), false);
+		index
+	}
+	
+	/// Adds the given edge to the graph
+	pub fn add_edge(&mut self, src: NodeIndex, dest: NodeIndex) -> Result<EdgeIndex, WouldCycle> {
+		self.inner.add_connection(src, dest)
+	}
+
+	/// Adds the given new node and input edge to the graph	
+	pub fn add_input(&mut self, src: DspNode, dest: NodeIndex) -> (EdgeIndex, NodeIndex) {
+		let (edge_index, node_index) = self.inner.add_input(src, dest);
+		self.free.insert(node_index.index(), false);
+		(edge_index, node_index)
+	}
+	
+	/// Checks whether the node at the given index exists
+	fn node_exists(&self, node: NodeIndex) -> bool {
+		let i = node.index();
+		if i < 0 || i > self.free.len() {
+			false
+		} else {
+			!self.free[i]
+		}
+	}
+	
+	/// An immutable reference to the node at the given index
+	pub fn node(&self, node: NodeIndex) -> Option<&DspNode> {
+		if self.node_exists(node) {
+			self.inner.node(node)
+		} else {
+			None
+		}
+	}
+	
+	/// A mutable reference to the node at the given index
+	pub fn node_mut(&mut self, node: NodeIndex) -> Option<&mut DspNode> {
+		if self.node_exists(node) {
+			self.inner.node_mut(node)
+		} else {
+			None
+		}
+	}
+	
+	/// An iterator over all (possibly freed) nodes at their corresponding indices
+	pub fn node_iter(&self) -> NodeIterator {
+		NodeIterator { nodes: self.inner.raw_nodes(), free: &self.free, i: 0 }
+	}
+	
+	/// An iterator over all edges in the graph
+	pub fn edge_iter(&self) -> EdgeIterator {
+		EdgeIterator { edges: self.inner.raw_edges(), i: 0 }
+	}
+	
+	/// Sets the master (output) node of this graph
+	pub fn set_master(&mut self, master: Option<NodeIndex>) {
+		self.inner.set_master(master);
+	}
+	
+	/// Requests audio from the master node
+	#[inline]
+	pub fn audio_requested(&mut self, output: &mut [StandardFrame], sample_hz: f64) {
+		self.inner.audio_requested(output, sample_hz)
+	}
+}
+
+/// An iterator over the nodes in an AudioGraph
+pub struct NodeIterator<'a> {
+	nodes: dsp::RawNodes<'a, DspNode>,
+	free: &'a Vec<bool>,
+	i: usize
+}
+
+impl<'a> Iterator for NodeIterator<'a> {
+	type Item = Option<&'a DspNode>;
+	
+	fn next(&mut self) -> Option<Option<&'a DspNode>> {
+		if self.i < self.nodes.len() {
+			let node = Some(&self.nodes[self.i].weight).filter(|_| !self.free[self.i]);
+			self.i += 1;
+			Some(node)
+		} else {
+			None
+		}
+	}
+}
+
+/// A directed edge
+pub struct Edge {
+	pub src: NodeIndex,
+	pub dest: NodeIndex
+}
+
+/// An iterator over the edges in an AudioGraph
+pub struct EdgeIterator<'a> {
+	edges: dsp::RawEdges<'a, StandardFrame>,
+	i: usize
+}
+
+impl<'a> Iterator for EdgeIterator<'a> {
+	type Item = Edge;
+	
+	fn next(&mut self) -> Option<Edge> {
+		if self.i < self.edges.len() {
+			let raw_edge = &self.edges[self.i];
+			self.i += 1;
+			Some(Edge { src: raw_edge.source(), dest: raw_edge.target() })
+		} else {
+			None
+		}
+	}
+}
 
 /// The audio graph which is shared between
 /// an engine and possibly control threads
 /// (such as RPC-mechanisms).
-pub type SharedAudioGraph = Arc<Mutex<Graph<StandardFrame, DspNode>>>;
+pub type SharedAudioGraph = Arc<Mutex<AudioGraph>>;
 
 pub fn new_shared_graph() -> SharedAudioGraph {
-	Arc::new(Mutex::new(Graph::new()))
+	Arc::new(Mutex::new(AudioGraph::new()))
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -40,6 +40,7 @@ impl AudioGraph {
 	
 	/// Adds the given edge to the graph
 	pub fn add_edge(&mut self, src: NodeIndex, dest: NodeIndex) -> Result<EdgeIndex, WouldCycle> {
+		// TODO: Prevent duplicate edges?
 		self.inner.add_connection(src, dest)
 	}
 	

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -78,14 +78,10 @@ impl AudioGraph {
 	
 	/// Removes a node from the graph in O(1).
 	/// 
-	/// Note that this will not actually remove the node
-	/// from the underlying data structure, but rather
-	/// mark the node index as free to be overwritten
-	/// by a new node.
-	/// 
 	/// Any indices referring to the given node should
 	/// be dropped by now.
 	pub fn remove_node(&mut self, node: NodeIndex) {
+		*self.node_mut(node).expect("Tried to remove non-existing node") = DspNode::Empty;
 		self.free[node.index()] = true;
 		self.has_free = true;
 	}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -92,7 +92,7 @@ impl AudioGraph {
 	/// Checks whether the node at the given index exists
 	fn node_exists(&self, node: NodeIndex) -> bool {
 		let i = node.index();
-		if i < 0 || i > self.free.len() {
+		if i > self.free.len() {
 			false
 		} else {
 			!self.free[i]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use graph::new_shared_graph;
 use engine::{AudioEngine, speaker::SpeakerEngine};
 use getopts::Options;
 use services::player::{AudioPlayerServiceRpc, AudioPlayerService};
+use services::graph::{AudioGraphServiceRpc, AudioGraphService};
 use std::env;
 use jsonrpc_core::IoHandler;
 use jsonrpc_stdio_server::ServerBuilder;
@@ -45,7 +46,8 @@ fn main() {
 
 	// Setup RPC services
 	let mut io = IoHandler::default();
-	io.extend_with(AudioPlayerService::constructing_graph(shared_graph, background_engine).to_delegate());
+	io.extend_with(AudioPlayerService::constructing_graph(shared_graph.clone(), background_engine).to_delegate());
+	io.extend_with(AudioGraphService::with_graph(shared_graph.clone()).to_delegate());
 	
 	ServerBuilder::new(io).build();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,8 @@ fn main() {
 
 	// Setup RPC services
 	let mut io = IoHandler::default();
-	io.extend_with(AudioPlayerService::constructing_graph(shared_graph.clone(), background_engine).to_delegate());
-	io.extend_with(AudioGraphService::using_graph(shared_graph.clone()).to_delegate());
+	io.extend_with(AudioPlayerService::constructing_graph(shared_graph.clone(), background_engine.clone()).to_delegate());
+	io.extend_with(AudioGraphService::using_graph(shared_graph.clone(), background_engine.clone()).to_delegate());
 	
 	ServerBuilder::new(io).build();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
 	// Setup RPC services
 	let mut io = IoHandler::default();
 	io.extend_with(AudioPlayerService::constructing_graph(shared_graph.clone(), background_engine).to_delegate());
-	io.extend_with(AudioGraphService::with_graph(shared_graph.clone()).to_delegate());
+	io.extend_with(AudioGraphService::using_graph(shared_graph.clone()).to_delegate());
 	
 	ServerBuilder::new(io).build();
 }

--- a/src/processing/filter.rs
+++ b/src/processing/filter.rs
@@ -149,6 +149,8 @@ impl<F> Disableable<F> {
 	pub fn enabled(wrapped: F) -> Disableable<F> { Disableable { wrapped: wrapped, disabled: false } }
 
 	pub fn disabled(wrapped: F) -> Disableable<F> { Disableable { wrapped: wrapped, disabled: true } }
+	
+	pub fn with<E>(&self, wrapped: E) -> Disableable<E> { Disableable { wrapped: wrapped, disabled: self.disabled } }
 }
 
 impl<F> Filter for Disableable<F> where F: Filter {

--- a/src/processing/filter.rs
+++ b/src/processing/filter.rs
@@ -146,6 +146,8 @@ pub struct Disableable<F> {
 }
 
 impl<F> Disableable<F> {
+	pub fn new(wrapped: F, disabled: bool) -> Disableable<F> { Disableable { wrapped: wrapped, disabled: disabled } }
+
 	pub fn enabled(wrapped: F) -> Disableable<F> { Disableable { wrapped: wrapped, disabled: false } }
 
 	pub fn disabled(wrapped: F) -> Disableable<F> { Disableable { wrapped: wrapped, disabled: true } }

--- a/src/processing/filter.rs
+++ b/src/processing/filter.rs
@@ -23,6 +23,7 @@ pub struct IIRLowpassFilter {
 }
 
 impl IIRLowpassFilter {
+	// TODO: Add cutoff_hz setter and make this a trait
 	pub fn with_cutoff_hz(cutoff_hz: f32, sample_hz: f64) -> IIRLowpassFilter {
 		let x = 2.0 * f32::consts::PI * (cutoff_hz / sample_hz as f32);
 		IIRLowpassFilter {
@@ -52,6 +53,7 @@ pub struct IIRHighpassFilter {
 }
 
 impl IIRHighpassFilter {
+	// TODO: Add cutoff_hz setter and make this a trait
 	pub fn with_cutoff_hz(cutoff_hz: f32, sample_hz: f64) -> IIRHighpassFilter {
 		let x = 2.0 * f32::consts::PI * (cutoff_hz / sample_hz as f32);
 		IIRHighpassFilter {

--- a/src/processing/filter.rs
+++ b/src/processing/filter.rs
@@ -141,7 +141,7 @@ impl Filter for MovingAverageFilter {
 /// A disableable filter that lets the original signal
 /// "pass-through" if disabled.
 pub struct Disableable<F> {
-	wrapped: F,
+	pub wrapped: F,
 	pub disabled: bool
 }
 

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -20,7 +20,7 @@ use crate::audioformat::{StandardFrame, empty_standard_frame};
 pub enum DspNode {
 	Empty,
 	Silence,
-	Source { src: Converter<Box<dyn Iterator<Item=StandardFrame> + Send>>, state: PauseState },
+	DynSource { src: Converter<Box<dyn Iterator<Item=StandardFrame> + Send>>, state: PauseState },
 	Volume(f32),
 	MovingAverage(Disableable<MovingAverageFilter>),
 	IIRLowpass(Disableable<IIRLowpassFilter>),
@@ -39,7 +39,7 @@ impl Node<StandardFrame> for DspNode {
 		match *self {
 			DspNode::Empty => (),
 			DspNode::Silence => silence(buffer),
-			DspNode::Source { ref mut src, ref state } => match state {
+			DspNode::DynSource { ref mut src, ref state } => match state {
 				PauseState::Playing => {
 					for i in 0..buffer.len() {
 						buffer[i] = src.next().unwrap_or_else(|| empty_standard_frame());

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -28,12 +28,6 @@ pub enum DspNode {
 	DynFilter(Box<dyn Filter + Send>)
 }
 
-/// A state of playback.
-pub enum PauseState {
-	Paused,
-	Playing
-}
-
 impl Node<StandardFrame> for DspNode {
 	fn audio_requested(&mut self, buffer: &mut [StandardFrame], _sample_hz: f64) {
 		match *self {

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -15,7 +15,7 @@ use crate::audioformat::{StandardFrame, empty_standard_frame};
 /// 
 /// _Generally_ all intermediate operations that perform modifications
 /// on the audio source (like pausing playback) should either
-/// be implemented as a parameter of `DspNode::Source` or in an
+/// be implemented as a parameter of `DspNode::DynSource` or in an
 /// `AudioSource` implementation wrapping another `AudioSource`.
 pub enum DspNode {
 	Empty,

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -7,6 +7,7 @@ use dsp::Node;
 use dsp::sample::rate::Converter;
 use dsp::sample::Frame;
 use filter::{Filter, MovingAverageFilter, IIRLowpassFilter, IIRHighpassFilter, Disableable};
+use crate::source::{AudioSource, file::FileSource};
 use crate::audioformat::{StandardFrame, empty_standard_frame};
 
 /// An audio processing node which can either be a source

--- a/src/services/graph.rs
+++ b/src/services/graph.rs
@@ -1,0 +1,87 @@
+use jsonrpc_core::Result as RpcResult;
+use jsonrpc_derive::rpc;
+use serde::{Serialize, Deserialize};
+use dsp::Graph;
+use crate::audioformat::StandardFrame;
+use crate::processing::DspNode;
+use crate::graph::SharedAudioGraph;
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RpcNode {
+	Empty,
+	Silence,
+	DynSource,
+	Volume,
+	IIRLowpass, // TODO: Store cutoff_hz by value here
+	IIRHighpass, // TODO: Store cutoff_hz by value here
+	DynFilter,
+	Other
+}
+
+impl RpcNode {
+	pub fn from(node: &DspNode) -> RpcNode {
+		match *node {
+			DspNode::Empty => RpcNode::Empty,
+			DspNode::Silence => RpcNode::Silence,
+			DspNode::DynSource { .. } => RpcNode::DynSource,
+			DspNode::Volume(..) => RpcNode::Volume,
+			DspNode::IIRLowpass { .. } => RpcNode::IIRLowpass,
+			DspNode::IIRHighpass { .. } => RpcNode::IIRHighpass,
+			DspNode::DynFilter(..) => RpcNode::DynFilter,
+			_ => RpcNode::Other
+		}
+	}
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RpcEdge {
+	pub src: usize,
+	pub dest: usize
+}
+
+impl RpcEdge {
+	pub fn between(src: usize, dest: usize) -> RpcEdge {
+		RpcEdge { src: src, dest: dest }
+	}
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RpcGraph {
+	pub nodes: Vec<RpcNode>,
+	pub edges: Vec<RpcEdge>
+}
+
+impl RpcGraph {
+	pub fn from(graph: &Graph<StandardFrame, DspNode>) -> RpcGraph {
+		RpcGraph {
+			nodes: graph.raw_nodes().iter().map(|node| RpcNode::from(&node.weight)).collect(),
+			edges: graph.raw_edges().iter().map(|edge| RpcEdge::between(edge.source().index(), edge.target().index())).collect()
+		}
+	}
+}
+
+/// The audio graph methods exposed via JSON-RPC
+#[rpc]
+pub trait AudioGraphServiceRpc {
+	/// Fetches the current state of the graph
+	#[rpc(name = "audioGraph.get")]
+	fn get(&self) -> RpcResult<RpcGraph>;
+}
+
+pub struct AudioGraphService {
+	shared_graph: SharedAudioGraph
+}
+
+impl AudioGraphService {
+	pub fn with_graph(shared_graph: SharedAudioGraph) -> AudioGraphService {
+		AudioGraphService { shared_graph: shared_graph }
+	}
+}
+
+impl AudioGraphServiceRpc for AudioGraphService {
+	fn get(&self) -> RpcResult<RpcGraph> {
+		let graph = self.shared_graph.lock().unwrap();
+		Ok(RpcGraph::from(&graph))
+	}
+}

--- a/src/services/graph.rs
+++ b/src/services/graph.rs
@@ -108,14 +108,16 @@ impl RpcEdge {
 #[derive(Serialize, Deserialize)]
 pub struct RpcGraph {
 	pub nodes: Vec<Option<RpcNode>>,
-	pub edges: Vec<RpcEdge>
+	pub edges: Vec<RpcEdge>,
+	pub master: Option<RpcNodeIndex>
 }
 
 impl RpcGraph {
 	pub fn from(graph: &AudioGraph) -> RpcGraph {
 		RpcGraph {
 			nodes: graph.node_iter().map(|opt_node| opt_node.map(|node| RpcNode::from(node))).collect(),
-			edges: graph.edge_iter().map(|edge| RpcEdge::between(edge.src.index(), edge.dest.index())).collect()
+			edges: graph.edge_iter().map(|edge| RpcEdge::between(edge.src.index(), edge.dest.index())).collect(),
+			master: graph.master().map(|i| i.index())
 		}
 	}
 }

--- a/src/services/graph.rs
+++ b/src/services/graph.rs
@@ -11,17 +11,36 @@ use crate::engine::BackgroundEngine;
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum RpcNode {
+	/// An empty/passthrough node
 	Empty,
+	/// An actively silencing node
 	Silence,
+	/// A volume-controllable node
 	#[serde(rename_all = "camelCase")]
-	Volume { #[serde(default)] level: f32 },
+	Volume {
+		#[serde(default)] level: f32
+	},
+	/// A file source
 	#[serde(rename_all = "camelCase")]
-	File { file_path: String, #[serde(default)] paused: bool },
+	File {
+		file_path: String,
+		#[serde(default)] paused: bool
+	},
+	/// A lowpass filter
 	#[serde(rename_all = "camelCase")]
-	IIRLowpass { #[serde(default)] cutoff_hz: f32, #[serde(default)] disabled: bool },
+	IIRLowpass {
+		#[serde(default)] cutoff_hz: f32,
+		#[serde(default)] disabled: bool
+	},
+	/// A highpass filter
 	#[serde(rename_all = "camelCase")]
-	IIRHighpass { #[serde(default)] cutoff_hz: f32, #[serde(default)] disabled: bool },
+	IIRHighpass {
+		#[serde(default)] cutoff_hz: f32,
+		#[serde(default)] disabled: bool
+	},
+	/// A dynamically dispatched filter (note that setting these is currently not supported)
 	DynFilter,
+	/// Any other node that currently has no RPC-serializable equivalent
 	Other
 }
 

--- a/src/services/graph.rs
+++ b/src/services/graph.rs
@@ -14,9 +14,12 @@ pub enum RpcNode {
 	Empty,
 	Silence,
 	Volume(f32),
-	File { file_path: String, paused: bool },
-	IIRLowpass { cutoff_hz: f32, disabled: bool },
-	IIRHighpass { cutoff_hz: f32, disabled: bool },
+	#[serde(rename_all = "camelCase")]
+	File { file_path: String, #[serde(default)] paused: bool },
+	#[serde(rename_all = "camelCase")]
+	IIRLowpass { #[serde(default)] cutoff_hz: f32, #[serde(default)] disabled: bool },
+	#[serde(rename_all = "camelCase")]
+	IIRHighpass { #[serde(default)] cutoff_hz: f32, #[serde(default)] disabled: bool },
 	DynFilter,
 	Other
 }
@@ -107,6 +110,8 @@ pub trait AudioGraphServiceRpc {
 	/// Adds a node to the graph, returning its index
 	#[rpc(name = "audioGraph.addNode")]
 	fn add_node(&self, node: RpcNode) -> RpcResult<RpcNodeIndex>;
+	
+	/// Creates a new template 
 	
 	/// Removes a node from the graph
 	#[rpc(name = "audioGraph.removeNode")]

--- a/src/services/graph.rs
+++ b/src/services/graph.rs
@@ -13,8 +13,8 @@ pub enum RpcNode {
 	Silence,
 	DynSource,
 	Volume(f32),
-	IIRLowpass { cutoff_hz: f32, disabled: bool }, // TODO: Store cutoff_hz by value here
-	IIRHighpass { cutoff_hz: f32, disabled: bool }, // TODO: Store cutoff_hz by value here
+	IIRLowpass { cutoff_hz: f32, disabled: bool },
+	IIRHighpass { cutoff_hz: f32, disabled: bool },
 	DynFilter,
 	Other
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 //! The JSON-RPC interface exposed to the user,
 //! e.g. player controls.
 pub mod player;
+pub mod graph;
 mod rpcutils;

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -1,13 +1,10 @@
 use jsonrpc_core::Result as RpcResult;
 use jsonrpc_derive::rpc;
 use super::rpcutils::server_error;
-use std::fs::File;
-use std::io::BufReader;
 use dsp::NodeIndex;
-use dsp::sample::rate::Converter;
-use crate::source::{AudioSource, pausable::Pausable, conv::Converting, file::FileSource};
+use crate::source::{pausable::Pausable, conv::Converting, file::FileSource};
 use crate::graph::SharedAudioGraph;
-use crate::processing::{DspNode, PauseState, filter::{Disableable, IIRLowpassFilter, IIRHighpassFilter}};
+use crate::processing::{DspNode, filter::{Disableable, IIRLowpassFilter, IIRHighpassFilter}};
 use crate::engine::{BackgroundEngine, ControlMsg};
 
 /// The audio playing service methods exposed via JSON-RPC.

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -70,8 +70,8 @@ impl AudioPlayerService {
 
 			let master_node = graph.add_node(DspNode::Empty);
 			volume_node = graph.add_input(DspNode::Empty, master_node).1;
-			lowpass_node = graph.add_input(DspNode::IIRLowpass(Disableable::disabled(IIRLowpassFilter::with_cutoff_hz(500.0, engine.sample_hz))), volume_node).1;
-			highpass_node = graph.add_input(DspNode::IIRHighpass(Disableable::disabled(IIRHighpassFilter::with_cutoff_hz(13_000.0, engine.sample_hz))), lowpass_node).1;
+			lowpass_node = graph.add_input(DspNode::IIRLowpass(Disableable::disabled(IIRLowpassFilter::from_cutoff_hz(500.0, engine.sample_hz))), volume_node).1;
+			highpass_node = graph.add_input(DspNode::IIRHighpass(Disableable::disabled(IIRHighpassFilter::from_cutoff_hz(13_000.0, engine.sample_hz))), lowpass_node).1;
 			src_node = graph.add_input(DspNode::Empty, highpass_node).1;
 
 			graph.set_master(Some(master_node));

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -98,7 +98,7 @@ impl AudioPlayerServiceRpc for AudioPlayerService {
 		let src_ref = graph.node_mut(self.src_node).expect("Audio graph has no source node");
 		
 		// TODO: Queueing?
-		*src_ref = DspNode::Source {
+		*src_ref = DspNode::DynSource {
 			src: Converter::from_hz_to_hz(Box::new(source), source_hz, self.engine.sample_hz),
 			state: PauseState::Playing
 		};

--- a/src/source/conv.rs
+++ b/src/source/conv.rs
@@ -17,6 +17,8 @@ impl<S> Converting<S> where S: AudioSource {
 			target_sample_hz: target_sample_hz
 		}
 	}
+	
+	pub fn wrapped(&self) -> &S { self.converter.source() }
 }
 
 impl<S> AudioSource for Converting<S> where S: AudioSource {

--- a/src/source/conv.rs
+++ b/src/source/conv.rs
@@ -1,0 +1,30 @@
+use dsp::sample::rate::Converter;
+use crate::audioformat::StandardFrame;
+use super::AudioSource;
+
+/// An audio source that automatically converts to
+/// a target sample rate.
+pub struct Converting<S> where S: AudioSource {
+	converter: Converter<S>,
+	target_sample_hz: f64
+}
+
+impl<S> Converting<S> where S: AudioSource {
+	pub fn to_sample_hz(target_sample_hz: f64, wrapped: S) -> Converting<S> {
+		let source_sample_hz = wrapped.sample_hz();
+		Converting {
+			converter: Converter::from_hz_to_hz(wrapped, source_sample_hz, target_sample_hz),
+			target_sample_hz: target_sample_hz
+		}
+	}
+}
+
+impl<S> AudioSource for Converting<S> where S: AudioSource {
+	fn sample_hz(&self) -> f64 { self.target_sample_hz }
+}
+
+impl<S> Iterator for Converting<S> where S: AudioSource {
+	type Item = StandardFrame;
+	
+	fn next(&mut self) -> Option<StandardFrame> { self.converter.next() }
+}

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -1,0 +1,74 @@
+use std::io::BufReader;
+use std::fs::File;
+use crate::audioformat::StandardFrame;
+use super::mp3::Mp3Source;
+use super::AudioSource;
+
+/// An audio source whose format can automatically
+/// be determined from the file's path upon construction.
+pub enum DecoderSource {
+	Mp3(Mp3Source<BufReader<File>>)
+	// TODO: Other formats
+}
+
+impl DecoderSource {
+	/// Tries to recognize the file's format and
+	/// create an appropriate decoder source for it.
+	/// Otherwise returns None.
+	fn from(file_path: &str) -> Option<DecoderSource> {
+		let splittable_path = file_path.clone();
+		let splitter = splittable_path.split(".");
+		let reader = BufReader::new(File::open(file_path).ok()?);
+		match splitter.last()?.as_ref() {
+			"mp3" => Some(DecoderSource::Mp3(Mp3Source::new(reader))),
+			// TODO: Other formats
+			_ => None
+		}
+	}
+}
+
+impl AudioSource for DecoderSource {
+	fn sample_hz(&self) -> f64 {
+		match *self {
+			DecoderSource::Mp3(ref src) => src.sample_hz()
+		}
+	}
+}
+
+impl Iterator for DecoderSource {
+	type Item = StandardFrame;
+	
+	fn next(&mut self) -> Option<StandardFrame> {
+		match *self {
+			DecoderSource::Mp3(ref mut src) => src.next()
+		}
+	}
+}
+
+/// A wrapper around a decoder source that maintains
+/// a path to the file it was created from.
+pub struct FileSource {
+	decoder: DecoderSource,
+	file_path: String
+}
+
+impl FileSource {
+	pub fn new(file_path: String) -> Option<FileSource> {
+		Some(FileSource {
+			decoder: DecoderSource::from(file_path.as_ref())?,
+			file_path: file_path
+		})
+	}
+	
+	pub fn file_path(&self) -> &str { self.file_path.as_ref() }
+}
+
+impl AudioSource for FileSource {
+	fn sample_hz(&self) -> f64 { self.decoder.sample_hz() }
+}
+
+impl Iterator for FileSource {
+	type Item = StandardFrame;
+	
+	fn next(&mut self) -> Option<StandardFrame> { self.decoder.next() }
+}

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -6,7 +6,7 @@ use super::AudioSource;
 
 /// An audio source whose format can automatically
 /// be determined from the file's path upon construction.
-pub enum DecoderSource {
+enum DecoderSource {
 	Mp3(Mp3Source<BufReader<File>>)
 	// TODO: Other formats
 }

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -53,10 +53,10 @@ pub struct FileSource {
 }
 
 impl FileSource {
-	pub fn new(file_path: String) -> Option<FileSource> {
+	pub fn new(file_path: &str) -> Option<FileSource> {
 		Some(FileSource {
-			decoder: DecoderSource::from(file_path.as_ref())?,
-			file_path: file_path
+			decoder: DecoderSource::from(file_path)?,
+			file_path: file_path.to_owned()
 		})
 	}
 	

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod mp3;
 pub mod file;
+pub mod pausable;
 
 use crate::audioformat::StandardFrame;
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,6 +1,7 @@
 //! A collection of audio sources.
 
 pub mod mp3;
+pub mod file;
 
 use crate::audioformat::StandardFrame;
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -12,6 +12,7 @@ pub trait AudioSource: Iterator<Item=StandardFrame> {
 	fn sample_hz(&self) -> f64;
 }
 
+/// A silent source.
 pub struct EmptySource;
 
 impl AudioSource for EmptySource {
@@ -23,4 +24,3 @@ impl Iterator for EmptySource {
 
 	fn next(&mut self) -> Option<StandardFrame> { None }
 }
-

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -3,6 +3,7 @@
 pub mod mp3;
 pub mod file;
 pub mod pausable;
+pub mod conv;
 
 use crate::audioformat::StandardFrame;
 

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -1,0 +1,34 @@
+use crate::audioformat::StandardFrame;
+use super::AudioSource;
+
+/// A source that can be paused. When paused, the
+/// source will not request any frames from its
+/// wrapped source.
+pub struct PausableSource<S> {
+	pub wrapped: S,
+	pub paused: bool
+}
+
+impl<S> PausableSource<S> {
+	pub fn paused(wrapped: S) -> PausableSource<S> { PausableSource { wrapped: wrapped, paused: true } }
+	
+	pub fn playing(wrapped: S) -> PausableSource<S> { PausableSource { wrapped: wrapped, paused: true } }
+	
+	pub fn with<T>(&self, wrapped: T) -> PausableSource<T> { PausableSource { wrapped: wrapped, paused: self.paused } }
+}
+
+impl<S> AudioSource for PausableSource<S> where S: AudioSource {
+	fn sample_hz(&self) -> f64 { self.wrapped.sample_hz() }
+}
+
+impl<S> Iterator for PausableSource<S> where S: AudioSource {
+	type Item = StandardFrame;
+	
+	fn next(&mut self) -> Option<StandardFrame> {
+		if self.paused {
+			None
+		} else {
+			self.wrapped.next()
+		}
+	}
+}

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -4,24 +4,26 @@ use super::AudioSource;
 /// A source that can be paused. When paused, the
 /// source will not request any frames from its
 /// wrapped source.
-pub struct PausableSource<S> {
+pub struct Pausable<S> {
 	pub wrapped: S,
 	pub paused: bool
 }
 
-impl<S> PausableSource<S> {
-	pub fn paused(wrapped: S) -> PausableSource<S> { PausableSource { wrapped: wrapped, paused: true } }
+impl<S> Pausable<S> {
+	pub fn new(wrapped: S, paused: bool) -> Pausable<S> { Pausable { wrapped: wrapped, paused: paused } }
+
+	pub fn paused(wrapped: S) -> Pausable<S> { Pausable { wrapped: wrapped, paused: true } }
 	
-	pub fn playing(wrapped: S) -> PausableSource<S> { PausableSource { wrapped: wrapped, paused: true } }
+	pub fn playing(wrapped: S) -> Pausable<S> { Pausable { wrapped: wrapped, paused: true } }
 	
-	pub fn with<T>(&self, wrapped: T) -> PausableSource<T> { PausableSource { wrapped: wrapped, paused: self.paused } }
+	pub fn with<T>(&self, wrapped: T) -> Pausable<T> { Pausable { wrapped: wrapped, paused: self.paused } }
 }
 
-impl<S> AudioSource for PausableSource<S> where S: AudioSource {
+impl<S> AudioSource for Pausable<S> where S: AudioSource {
 	fn sample_hz(&self) -> f64 { self.wrapped.sample_hz() }
 }
 
-impl<S> Iterator for PausableSource<S> where S: AudioSource {
+impl<S> Iterator for Pausable<S> where S: AudioSource {
 	type Item = StandardFrame;
 	
 	fn next(&mut self) -> Option<StandardFrame> {


### PR DESCRIPTION
Add a graph service to dynamically mutate the audio graph at runtime using JSON-RPC.

Additionally, implement a wrapper on top of the DSP audio graph that uses stable node indices.